### PR TITLE
Add flow layout for header labels

### DIFF
--- a/src/csv2json/gui/components/flow_layout.py
+++ b/src/csv2json/gui/components/flow_layout.py
@@ -1,0 +1,110 @@
+"""
+FlowLayout implementation for PyQt6.
+Based on the Qt6 examples.
+"""
+
+from PyQt6.QtCore import QPoint, QRect, QSize, Qt
+from PyQt6.QtWidgets import QLayout, QSizePolicy
+
+
+class FlowLayout(QLayout):
+    """
+    A layout that arranges widgets in a flow, similar to how text flows in a paragraph.
+    """
+    def __init__(self, parent=None, margin=0, spacing=-1):
+        super().__init__(parent)
+        self.setContentsMargins(margin, margin, margin, margin)
+        self.setSpacing(spacing)
+        self._item_list = []
+
+    def __del__(self):
+        item = self.takeAt(0)
+        while item:
+            item = self.takeAt(0)
+
+    def addItem(self, item):
+        self._item_list.append(item)
+
+    def count(self):
+        return len(self._item_list)
+
+    def itemAt(self, index):
+        if 0 <= index < len(self._item_list):
+            return self._item_list[index]
+        return None
+
+    def takeAt(self, index):
+        if 0 <= index < len(self._item_list):
+            return self._item_list.pop(index)
+        return None
+
+    def expandingDirections(self):
+        return Qt.Orientation(0)
+
+    def hasHeightForWidth(self):
+        return True
+
+    def heightForWidth(self, width):
+        height = self._do_layout(QRect(0, 0, width, 0), True)
+        return height
+
+    def setGeometry(self, rect):
+        super().setGeometry(rect)
+        self._do_layout(rect, False)
+
+    def sizeHint(self):
+        return self.minimumSize()
+
+    def minimumSize(self):
+        size = QSize()
+        for item in self._item_list:
+            size = size.expandedTo(item.minimumSize())
+        margin = self.contentsMargins()
+        size += QSize(margin.left() + margin.right(), margin.top() + margin.bottom())
+        return size
+
+    def _do_layout(self, rect, test_only):
+        x = rect.x()
+        y = rect.y()
+        line_height = 0
+        spacing = self.spacing()
+        
+        for item in self._item_list:
+            widget = item.widget()
+            style = widget.style() if widget else None
+            
+            # Get the spacing between widgets
+            layout_spacing_x = spacing
+            layout_spacing_y = spacing
+            
+            if style:
+                layout_spacing_x = style.layoutSpacing(
+                    QSizePolicy.ControlType.PushButton,
+                    QSizePolicy.ControlType.PushButton,
+                    Qt.Orientation.Horizontal
+                )
+                layout_spacing_y = style.layoutSpacing(
+                    QSizePolicy.ControlType.PushButton,
+                    QSizePolicy.ControlType.PushButton,
+                    Qt.Orientation.Vertical
+                )
+            
+            # Calculate the next position
+            next_x = x + item.sizeHint().width() + layout_spacing_x
+            
+            # If we would exceed the right edge, move to the next line
+            if next_x - layout_spacing_x > rect.right() and line_height > 0:
+                x = rect.x()
+                y = y + line_height + layout_spacing_y
+                next_x = x + item.sizeHint().width() + layout_spacing_x
+                line_height = 0
+            
+            # Place the item if not just testing
+            if not test_only:
+                item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
+            
+            # Update position and line height
+            x = next_x
+            line_height = max(line_height, item.sizeHint().height())
+        
+        return y + line_height - rect.y()

--- a/src/csv2json/gui/components/mapping_chips.py
+++ b/src/csv2json/gui/components/mapping_chips.py
@@ -2,11 +2,12 @@
 Draggable chips component for the CSV2JSON converter.
 """
 
-from PyQt6.QtWidgets import QLabel, QFrame, QHBoxLayout, QSizePolicy
+from PyQt6.QtWidgets import QLabel, QFrame, QSizePolicy
 from PyQt6.QtCore import Qt, QMimeData
 from PyQt6.QtGui import QDrag
 
 from src.csv2json.core.logging import logger
+from src.csv2json.gui.components.flow_layout import FlowLayout
 
 
 class DraggableChip(QLabel):
@@ -17,21 +18,41 @@ class DraggableChip(QLabel):
         super().__init__(text, parent)
         self.update_style()
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+
+        # Enable word wrap for long text
+        self.setWordWrap(True)
+
+        # Set maximum width to prevent overly wide chips
+        self.setMaximumWidth(200)
+
+        # Ensure text is properly displayed with ellipsis if needed
+        self.setTextFormat(Qt.TextFormat.PlainText)
 
         # Store the original text
         self.original_text = text
 
+        # Set tooltip to show full text on hover
+        self.setToolTip(text)
+
+        # Adjust height based on content
+        self.adjustSize()
+
+        # Log the chip creation
+        logger.debug(f"Created chip for field: {text}")
+
     def update_style(self):
         """Update the style based on the theme mode."""
-        # Minimal styling for the chip
+        # Enhanced styling for the chip with better text handling
         self.setStyleSheet("""
             QLabel {
                 background-color: palette(highlight);
                 color: palette(highlightedText);
                 border-radius: 10px;
-                padding: 5px 10px;
-                margin: 2px;
+                padding: 6px 10px;
+                margin: 3px;
+                min-height: 20px;
+                max-height: 60px;
             }
         """)
 
@@ -64,28 +85,34 @@ class DraggableChip(QLabel):
 
 class ChipContainer(QFrame):
     """
-    A container for draggable chips.
+    A container for draggable chips that arranges them in a flowing layout.
     """
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setAcceptDrops(True)
         self.update_style()
 
-        # Create a flow layout for the chips
-        self.layout = QHBoxLayout(self)
-        self.layout.setSpacing(5)
-        self.layout.setContentsMargins(10, 10, 10, 10)
-        self.layout.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        # Create a flow layout for the chips that wraps to the next line
+        self.layout = FlowLayout(self, margin=10, spacing=5)
 
         # Store the chips
         self.chips = []
 
+        # Set minimum height to ensure there's always space for chips
+        self.setMinimumHeight(100)
+
+        # Log container creation
+        logger.debug("Created chip container with flow layout")
+
     def update_style(self):
         """Update the style based on the theme mode."""
-        # Minimal styling for the container
+        # Enhanced styling for the container
         self.setStyleSheet("""
             ChipContainer {
-                min-height: 50px;
+                min-height: 100px;
+                border: 1px solid palette(mid);
+                border-radius: 5px;
+                background-color: palette(base);
             }
         """)
 


### PR DESCRIPTION
## Description
When loading a file with a lot of headers, the chips for the mapping were cramped together. This PR fixes that by using a FlowLayout to allow the labels to flow to the next line, if necessary.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Manual testing
- [ ] Automated tests added/updated

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/9b1dbd51-84ec-4c02-ad17-d1e38d4b968c)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
